### PR TITLE
[ Nginx ] default site error fix

### DIFF
--- a/bz-webserver/recipes/nginx.rb
+++ b/bz-webserver/recipes/nginx.rb
@@ -2,6 +2,10 @@ include_recipe "bz-webserver::common"
 
 include_recipe "nginx"
 
+file "/etc/nginx/sites-enabled/default" do
+  action :delete
+end
+
 template "/etc/nginx/sites-enabled/#{node['bz-server']['app']['name']}-vhost" do
   source "nginx-vhost.erb"
   notifies :reload, "service[nginx]", :immediately


### PR DESCRIPTION
I made following:

vagrant up
cap vagrant deploy

And when I got an issue in browser:

404 Not Found nginx/1.1.19

I tried to debug and found:

tail -f /var/log/nginx/error.log
[error] 11238#0: *1 "/var/www/nginx-default/index.html" is not found (2: No such file or directory)

So, it seems that Nginx still waiting for /etc/nginx/sites-enabled/default site.

vagrant@precise64:/var/log/nginx$ cd /etc/nginx/sites-enabled/
vagrant@precise64:/etc/nginx/sites-enabled$ ls
default  online-therapy-vhost

Then I delete default site and it works:

vagrant@precise64:/etc/nginx/sites-enabled$ sudo rm -rf default 
vagrant@precise64:/etc/nginx/sites-enabled$ sudo service nginx restart
Restarting nginx: nginx.

So, I decided to add it to cookbooks.
Tested, works:

[2014-01-22T13:45:48+00:00] INFO: service[nginx] started
[2014-01-22T13:45:48+00:00] INFO: file[/etc/nginx/sites-enabled/default] deleted file at /etc/nginx/sites-enabled/default
[2014-01-22T13:45:49+00:00] INFO: template[/etc/nginx/sites-enabled/online-therapy-vhost] updated content
[2014-01-22T13:45:49+00:00] INFO: template[/etc/nginx/sites-enabled/online-therapy-vhost] sending reload action to service[nginx](immediate)
[2014-01-22T13:45:49+00:00] INFO: service[nginx] reloaded
