### PR TITLE
README - added note about vagrant-berkshelf version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ NOTE: **all cookbooks should have the same version**. Consider this to be a stac
 ````shell
 vagrant plugin install vagrant-berkshelf
 ````
+If you are using Vagrant 1.4.3 use this:
+
+````shell
+vagrant plugin install vagrant-berkshelf --plugin-version 1.3.7
+````
 
 ###### Install [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus).
 


### PR DESCRIPTION
If you are using Vagrant 1.4.3 use vagrant-berkshelf --plugin-version 1.3.7
to avoid error: ".vagrant.d/gems/gems/vagrant-berkshelf-2.0.0/lib/berkshelf/vagrant/env.rb:16:in `initialize': undefined method`opts' for #<Vagrant::
UI::Colored:0x565e7c8>"
