### PR TITLE
Nginx 'user' option fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+## 0.2.5
+
+* NGINX: fixed issue with user www-data option in nginx.conf.erb, which caused on Centos
+  Original issue description: https://tickets.opscode.com/browse/COOK-3397?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel
+* Updated 'ubuntu' cookbook from "1.1.7" to "1.1.8"
+
 ## 0.2.1
 
 * removed bzcibot

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 depends          'database', '2.2.1'
 depends          'mongodb', '0.16.1'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/Berksfile.in
+++ b/bz-server/Berksfile.in
@@ -2,7 +2,7 @@ cookbook 'hostsfile', '2.4.5'
 cookbook 'apt', '2.4.0'
 cookbook 'ufw', '0.7.4'
 cookbook 'ohai', '2.0.1'
-cookbook 'ubuntu', '1.1.7', github: 'opscode-cookbooks/ubuntu'
+cookbook 'ubuntu', '1.1.8', github: 'opscode-cookbooks/ubuntu'
 cookbook 'line', '0.5.1'
 cookbook 'unattended-upgrades', '0.0.1', github: "bitzesty/chef-unattended-upgrades"
 cookbook 'database', '~> 2.2', github: 'opscode-cookbooks/database'

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.4"
+version          "0.2.5"
 
 depends          'nginx'
 depends          'varnish'

--- a/bz-webserver/templates/default/nginx.conf.erb
+++ b/bz-webserver/templates/default/nginx.conf.erb
@@ -1,4 +1,4 @@
-user www-data;
+user <%= node['nginx']['user'] %>;
 worker_processes <%= node['bz-webserver']['nginx']['worker_processes'] %>;
 pid /var/run/nginx.pid;
 


### PR DESCRIPTION
- NGINX: fixed issue with user www-data option in nginx.conf.erb, which caused on Centos
  
  Original issue description: https://tickets.opscode.com/browse/COOK-3397?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel
  
  We can't use standart:
  
  ```
  use www-data; # in bz-webserver/templates/default/nginx.conf.erb
  ```
  
  because value of this setting can be different for different platforms
  https://github.com/miketheman/nginx/blob/master/attributes/default.rb#L35
- Updated 'ubuntu' cookbook from "1.1.7" to "1.1.8"
