### PR TITLE
NGINX: issue with 'default' conf files on Centos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Master
 
+## 0.2.6
+
+* NGINX: fixed issue with displaying "Welcome NGINX" page for some non ubuntu platforms.
+  For example: Centos use Nginx on EPEL, which populates /etc/nginx/conf.d/default.conf
+  So, it will be loaded at first, because in bz-webserver/templates/default/nginx.conf.erb
+  we have following lines:
+  ```
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+  ```
+
 ## 0.2.5
 
 * NGINX: fixed issue with user www-data option in nginx.conf.erb, which caused on Centos

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 depends          'database', '2.2.1'
 depends          'mongodb', '0.16.1'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 depends          'nginx'
 depends          'varnish'

--- a/bz-webserver/recipes/nginx.rb
+++ b/bz-webserver/recipes/nginx.rb
@@ -25,6 +25,12 @@ file "/etc/nginx/sites-enabled/default" do
   action :delete
 end
 
+# For Centos and remove default site configuration
+file "/etc/nginx/conf.d/default.conf" do
+  action :delete
+  only_if do FileTest.exist?("/etc/nginx/conf.d/default.conf") end
+end
+
 # create log and certs dirs
 [
 node['bz-webserver']['nginx']['log']['dir'],


### PR DESCRIPTION
- NGINX: fixed issue with displaying "Welcome NGINX" page for some non ubuntu platforms.
  
  For example: 
  Centos use Nginx on EPEL, which populates /etc/nginx/conf.d/default.conf
  So, it will be loaded at first, because in bz-webserver/templates/default/nginx.conf.erb
  we have following lines:
  
  ```
    include /etc/nginx/conf.d/*.conf;
    include /etc/nginx/sites-enabled/*;
  ```
