### PR TITLE
Update database and mysql cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Master
 
+## 0.2.7
+
+* Updated 'database' from '2.2.1' to '2.3.0'
+* Updated 'mysql' from '5.3.6' to '5.4.4'
+
 ## 0.2.6
 
 * NGINX: fixed issue with displaying "Welcome NGINX" page for some non ubuntu platforms.

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
-depends          'database', '2.2.1'
+depends          'database', '2.3.0'
 depends          'mongodb', '0.16.1'
 depends          'postgresql', '3.4.1'
 depends          'redisio', '1.7.1'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/Berksfile.in
+++ b/bz-server/Berksfile.in
@@ -5,8 +5,8 @@ cookbook 'ohai', '2.0.1'
 cookbook 'ubuntu', '1.1.8', github: 'opscode-cookbooks/ubuntu'
 cookbook 'line', '0.5.1'
 cookbook 'unattended-upgrades', '0.0.1', github: "bitzesty/chef-unattended-upgrades"
-cookbook 'database', '~> 2.2', github: 'opscode-cookbooks/database'
-cookbook 'mysql', '~> 5.3.6', github: 'opscode-cookbooks/mysql'
+cookbook 'database', '~> 2.3.0', github: 'opscode-cookbooks/database'
+cookbook 'mysql', '~> 5.4.4', github: 'opscode-cookbooks/mysql'
 
 # does not notify via emails
 # monit uses too old yum cookbook

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.6"
+version          "0.2.7"
 
 depends          'nginx'
 depends          'varnish'


### PR DESCRIPTION
- Updated 'database' from '2.2.1' to '2.3.0'
- Updated 'mysql' from '5.3.6' to '5.4.4'

Tested with on vagrant and rackspace for new TSS servers.
