### PR TITLE
Version 0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Master
 
+## 0.2.10
+    
+* Updated 'redisio' from '2.2.3' to '2.2.4'
+* Updated 'apt' from '2.4.0' to '2.6.0'
+* Updated 'nginx' from '2.7.0' to '2.7.4'
+* Replaced 'nginx-extra' with 'nginx-full' (as it causes 'shared memory' issue in some envs)
+* Set 'varnish' cookbook to use bitzesty's fork
+* Disabled using of custom 'storage_file' in bz-webserver/attributes/varnish.rb for time being (see https://github.com/rackspace-cookbooks/varnish/issues/39)
+
 ## 0.2.9
 
 * Updated 'redisio' from '1.7.1' to '2.2.3'

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.9"
+version          "0.2.10"
 
 depends          'database', '2.3.0'
 depends          'mongodb', '0.16.1'
 depends          'postgresql', '3.4.1'
-depends          'redisio', '2.2.3'
+depends          'redisio', '2.2.4'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.9"
+version          "0.2.10"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.9"
+version          "0.2.10"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/Berksfile.in
+++ b/bz-server/Berksfile.in
@@ -1,5 +1,5 @@
 cookbook 'hostsfile', '2.4.5'
-cookbook 'apt', '2.4.0'
+cookbook 'apt', '2.6.0'
 cookbook 'ufw', '0.7.4'
 cookbook 'ohai', '2.0.1'
 cookbook 'ubuntu', '1.1.8', github: 'opscode-cookbooks/ubuntu'
@@ -16,7 +16,7 @@ cookbook 'newrelic-sysmond', '1.4.0'
 cookbook 'cloud_monitoring', '1.0.4', github: 'racker/cookbook-cloudmonitoring'
 cookbook 'java', '1.22.0'
 
-cookbook 'redisio', '2.2.3', github: 'brianbianco/redisio'
+cookbook 'redisio', '2.2.4', github: 'brianbianco/redisio'
 cookbook 'elasticsearch', '0.3.10'
 
 # monitoring

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.9"
+version          "0.2.10"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/Berksfile.in
+++ b/bz-webserver/Berksfile.in
@@ -1,2 +1,2 @@
-cookbook 'nginx', '~> 2.7', github: 'opscode-cookbooks/nginx'
-cookbook 'varnish', '~> 0.9.13', github: 'opscode-cookbooks/varnish'
+cookbook 'nginx', '~> 2.7.4', github: 'opscode-cookbooks/nginx'
+cookbook 'varnish', github: 'bitzesty/varnish'

--- a/bz-webserver/attributes/varnish.rb
+++ b/bz-webserver/attributes/varnish.rb
@@ -3,7 +3,10 @@ bz_varnish['listen_port'] = 80 # listen on 80 by default, nginx should go on 808
 # safe name for file location
 user_name = node['bz-server']['user']['name'].gsub(/-/, "_")
 bz_varnish['instance'] = user_name
-bz_varnish['storage_file'] = "/var/lib/varnish/#{user_name}/varnish_storage.bin"
+
+# Disabled using of custom 'storage_file' for time being (see https://github.com/rackspace-cookbooks/varnish/issues/39)
+# Possibly will return it later
+# bz_varnish['storage_file'] = "/var/lib/varnish/#{user_name}/varnish_storage.bin"
 
 # forward attributes to node['varnish']
 default['varnish'] = default['varnish'].merge(node['bz-webserver']['varnish'])

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.9"
+version          "0.2.10"
 
 depends          'nginx'
 depends          'varnish'

--- a/bz-webserver/recipes/nginx_debian_package.rb
+++ b/bz-webserver/recipes/nginx_debian_package.rb
@@ -24,7 +24,7 @@ execute "update apt to have passenger among packages" do
 end
 
 # install packages
-nginx_packages = %w(nginx-extras)
+nginx_packages = %w(nginx-full)
 if node['bz-server']['app']['rails_app_server'] == "passenger"
   # passenger must be installed before nginx
   nginx_packages.unshift "passenger"

--- a/bz-webserver/recipes/varnish.rb
+++ b/bz-webserver/recipes/varnish.rb
@@ -1,5 +1,5 @@
 # package via their repository
-include_recipe "varnish::apt_repo"
+include_recipe "varnish::repo"
 
 # install varnish
 include_recipe "varnish::default"


### PR DESCRIPTION
- Updated 'redisio' from '2.2.3' to '2.2.4'
- Updated 'apt' from '2.4.0' to '2.6.0'
- Updated 'nginx' from '2.7.0' to '2.7.4'
- Replaced 'nginx-extra' with 'nginx-full' (as it causes 'shared memory' issue in some envs)
- Set 'varnish' cookbook to use bitzesty's fork
- Disabled using of custom 'storage_file' in bz-webserver/attributes/varnish.rb for time being (see https://github.com/rackspace-cookbooks/varnish/issues/39)
