### PR TITLE
Version 0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Master
 
+## 0.2.11
+
+* Added security options to nginx.conf.erb:
+
+```
+more_clear_headers 'Server';
+more_clear_headers 'X-Powered-By';
+more_clear_headers 'X-Runtime';
+```
+
+* Updated 'mysql' from '5.5.2' to '5.6.1'
+
+* Removed setting of the version for cookbook 'serverdensity'
+  as it raises error while running "berks update"
+```
+The cookbook downloaded for serverdensity (= 2.0.0) did not satisfy the constraint.
+```
+
 ## 0.2.10
     
 * Updated 'redisio' from '2.2.3' to '2.2.4'

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.10"
+version          "0.2.11"
 
 depends          'database', '2.3.0'
 depends          'mongodb', '0.16.1'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.10"
+version          "0.2.11"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.10"
+version          "0.2.11"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/Berksfile.in
+++ b/bz-server/Berksfile.in
@@ -6,7 +6,7 @@ cookbook 'ubuntu', '1.1.8', github: 'opscode-cookbooks/ubuntu'
 cookbook 'line', '0.5.1'
 cookbook 'unattended-upgrades', '0.0.1', github: "bitzesty/chef-unattended-upgrades"
 cookbook 'database', '~> 2.3.0', github: 'opscode-cookbooks/database'
-cookbook 'mysql', '~> 5.5.2', github: 'opscode-cookbooks/mysql'
+cookbook 'mysql', '~> 5.6.1', github: 'opscode-cookbooks/mysql'
 
 # does not notify via emails
 # monit uses too old yum cookbook
@@ -20,4 +20,4 @@ cookbook 'redisio', '2.2.4', github: 'brianbianco/redisio'
 cookbook 'elasticsearch', '0.3.10'
 
 # monitoring
-cookbook 'serverdensity', '2.0.0', github: 'serverdensity/chef-serverdensity'
+cookbook 'serverdensity', github: 'serverdensity/chef-serverdensity'

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.10"
+version          "0.2.11"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.10"
+version          "0.2.11"
 
 depends          'nginx'
 depends          'varnish'

--- a/bz-webserver/recipes/nginx_debian_package.rb
+++ b/bz-webserver/recipes/nginx_debian_package.rb
@@ -24,7 +24,7 @@ execute "update apt to have passenger among packages" do
 end
 
 # install packages
-nginx_packages = %w(nginx-full)
+nginx_packages = %w(nginx-extras)
 if node['bz-server']['app']['rails_app_server'] == "passenger"
   # passenger must be installed before nginx
   nginx_packages.unshift "passenger"

--- a/bz-webserver/templates/default/nginx.conf.erb
+++ b/bz-webserver/templates/default/nginx.conf.erb
@@ -14,6 +14,9 @@ http {
   types_hash_max_size 1024;
   variables_hash_max_size 1024;
   server_tokens off;
+  more_clear_headers 'Server';
+  more_clear_headers 'X-Powered-By';
+  more_clear_headers 'X-Runtime';
 
   server_names_hash_bucket_size 64;
   # server_name_in_redirect off;


### PR DESCRIPTION
- Added security options to nginx.conf.erb:

```
more_clear_headers 'Server';
more_clear_headers 'X-Powered-By';
more_clear_headers 'X-Runtime';
```
- Updated 'mysql' from '5.5.2' to '5.6.1'
- Removed setting of the version for cookbook 'serverdensity'
  as it raises error while running "berks update"

```
The cookbook downloaded for serverdensity (= 2.0.0) did not satisfy the constraint.
```
