### PR TITLE
Version 0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+## 0.2.13
+
+* Added support for newer version of berkshelf, by removing `github` option from some of the cookbook paths
+* Added firewall cookbook dependency for the webserver cookbook, so it works on newer versions of Berkshelf
+* Upgrading postgresql cookbook to work better with the database cookbook
+
 ## 0.2.12
 
   * `bz-server::logrotate`: set max file size to 100MB by default for logrotate

--- a/bz-database/metadata.rb
+++ b/bz-database/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Database configurationr recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.12"
+version          "0.2.13"
 
 depends          'database', '2.3.0'
 depends          'mongodb', '0.16.1'
-depends          'postgresql', '3.4.1'
+depends          'postgresql', '3.4.18'
 depends          'redisio', '2.2.4'

--- a/bz-deployment/metadata.rb
+++ b/bz-deployment/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Application development via chef and capistrano recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.12"
+version          "0.2.13"
 
 # list dependencies
 # depends          'database'

--- a/bz-rails/metadata.rb
+++ b/bz-rails/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Rails app setup and maintenance related recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.12"
+version          "0.2.13"
 
 depends          'rbenv'
 depends          'ruby_build', '0.8.0'

--- a/bz-server/Berksfile.in
+++ b/bz-server/Berksfile.in
@@ -5,8 +5,8 @@ cookbook 'ohai', '2.0.1'
 cookbook 'ubuntu', '1.1.8', github: 'opscode-cookbooks/ubuntu'
 cookbook 'line', '0.5.1'
 cookbook 'unattended-upgrades', '0.0.1', github: "bitzesty/chef-unattended-upgrades"
-cookbook 'database', '~> 2.3.0', github: 'opscode-cookbooks/database'
-cookbook 'mysql', '~> 5.6.1', github: 'opscode-cookbooks/mysql'
+cookbook 'database', '~> 2.3.0'#, github: 'opscode-cookbooks/database'
+cookbook 'mysql', '~> 5.6.1'#, github: 'opscode-cookbooks/mysql'
 
 # does not notify via emails
 # monit uses too old yum cookbook
@@ -16,7 +16,7 @@ cookbook 'newrelic-sysmond', '1.4.0'
 cookbook 'cloud_monitoring', '1.0.4', github: 'racker/cookbook-cloudmonitoring'
 cookbook 'java', '1.22.0'
 
-cookbook 'redisio', '2.2.4', github: 'brianbianco/redisio'
+cookbook 'redisio', '2.2.4'#, github: 'brianbianco/redisio'
 cookbook 'elasticsearch', '0.3.10'
 
 # monitoring

--- a/bz-server/metadata.rb
+++ b/bz-server/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'General server configuration for any type of server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.12"
+version          "0.2.13"
 
 depends          'apt'
 depends          'ufw'

--- a/bz-webserver/Berksfile.in
+++ b/bz-webserver/Berksfile.in
@@ -1,2 +1,3 @@
-cookbook 'nginx', '~> 2.7.4', github: 'opscode-cookbooks/nginx'
+cookbook 'firewall'
+cookbook 'nginx', '~> 2.7.4'
 cookbook 'varnish', github: 'bitzesty/varnish'

--- a/bz-webserver/metadata.rb
+++ b/bz-webserver/metadata.rb
@@ -4,7 +4,8 @@ maintainer_email 'info@bitzesty.com'
 license          'All rights reserved'
 description      'Frontend webserver configuration recipe'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.12"
+version          "0.2.13"
 
 depends          'nginx'
 depends          'varnish'
+depends          'firewall'

--- a/bz-webserver/recipes/common.rb
+++ b/bz-webserver/recipes/common.rb
@@ -6,6 +6,7 @@ if platform_family?("rhel") && node['bz-webserver']['open-80-port']
 end
 
 if platform_family?("debian")
+  include_recipe 'firewall'
   firewall_rule "http" do
     port 80
     action :allow


### PR DESCRIPTION
. Upgrading postgresql cookbook to version `3.4.18`
. Removing github option from some of the cookbooks, as it was causing conflicts on newer versions of Berkshelf
. Added firewall cookbook as a dependency for `bz-webserver` as it was causing issues on newer versions of Berkshelf